### PR TITLE
updates for udp_flood/sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+*.o
+*.a
+*.so
+*~
+\#*#
+.#*
+
+# cscope
+cscope.*
+ncscope.*
+TAGS
+
+*.diff
+*.patch
+*.orig
+*.rej
+
+core.*
+vgcore.*

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,12 @@
+ipv6_example01
+overhead_cmpxchg
+qdisc_bypass_test
+syscall_overhead
+tcp_sink
+tcp_sink_client
+tcp_sink_epoll
+udp_client_echo
+udp_echo
+udp_example02
+udp_flood
+udp_sink

--- a/src/common.c
+++ b/src/common.c
@@ -103,3 +103,28 @@ int time_func(int loops,
 
 	return 0;
 }
+
+void print_result(uint64_t tsc_cycles, double ns_per_pkt, double pps,
+		  double timesec, int cnt_send, uint64_t tsc_interval)
+{
+	if (verbose) {
+		printf(" - Per packet: %lu cycles(tsc) %.2f ns, %.2f pps (time:%.2f sec)\n"
+		       "   (packet count:%d tsc_interval:%lu)\n",
+		       tsc_cycles, ns_per_pkt, pps, timesec,
+		       cnt_send, tsc_interval);
+	} else {
+		printf("%.2f\t%.2f\t%lu\n", ns_per_pkt, pps, tsc_interval);
+	}
+}
+
+void print_header(const char *fct, int batch)
+{
+	if (verbose && batch)
+		printf("\nPerformance of: %s, batch size: %d\n", fct, batch);
+	else if (verbose)
+		printf("\nPerformance of: %s\n", fct);
+	else if (batch)
+		printf("%s/%-4d\t", fct, batch);
+	else
+		printf("%-10s\t", fct);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,9 @@ inline uint64_t rdtsc()
 unsigned long long gettime(void);
 
 char *malloc_payload_buffer(int msg_sz);
+void print_result(uint64_t tsc_cycles, double ns_per_pkt, double pps,
+		  double timesec, int cnt_send, uint64_t tsc_interval);
+void print_header(const char *fct, int batch);
 
 /* Using __builtin_constant_p(x) to ignore cases where the return
  * value is always the same.

--- a/src/tcp_sink.c
+++ b/src/tcp_sink.c
@@ -38,7 +38,7 @@
 static int so_reuseport = 1;
 static int write_something = 0;
 
-static struct option long_options[] = {
+static const struct option long_options[] = {
 	{"ipv4",	no_argument,		NULL, '4' },
 	{"ipv6",	no_argument,		NULL, '6' },
 	{"listen-port",	required_argument,	NULL, 'l' },
@@ -47,7 +47,7 @@ static struct option long_options[] = {
 	{"quiet",	no_argument,		&verbose, 0 },
 	{"reuseport",	no_argument,		&so_reuseport, 1 },
 	{"no-reuseport",no_argument,		&so_reuseport, 0 },
-	{"write-back", 	no_argument,		&write_something, 1 },
+	{"write-back",	no_argument,		&write_something, 1 },
 	{0, 0, NULL,  0 }
 };
 

--- a/src/udp_flood.c
+++ b/src/udp_flood.c
@@ -35,13 +35,45 @@
 #define RUN_WRITE     0x8
 #define RUN_ALL       (RUN_SENDMSG | RUN_SENDMMSG | RUN_SENDTO | RUN_WRITE)
 
+static const struct option long_options[] = {
+	{"help",	no_argument,		NULL, 'h' },
+	{"ipv4",	no_argument,		NULL, '4' },
+	{"ipv6",	no_argument,		NULL, '6' },
+	/* keep these grouped together */
+	{"sendmsg",	no_argument,		NULL, 'u' },
+	{"sendmmsg",	no_argument,		NULL, 'U' },
+	{"sendto",	no_argument,		NULL, 't' },
+	{"write",	no_argument,		NULL, 'T' },
+	{"batch",	required_argument,	NULL, 'b' },
+	{"count",	required_argument,	NULL, 'c' },
+	{"port",	required_argument,	NULL, 'p' },
+	{"payload",	required_argument,	NULL, 'm' },
+	{"verbose",	optional_argument,	NULL, 'v' },
+	{0, 0, NULL,  0 }
+};
 
 static int usage(char *argv[])
 {
+	int i;
+
 	printf("-= ERROR: Parameter problems =-\n");
-	printf(" Usage: %s [-c count] [-p port] [-m payloadsize] [-4] [-6] [-v] [-t] [-u] [-U] IPADDR\n\n",
+	printf(" Usage: %s (options-see-below) IPADDR\n",
 	       argv[0]);
-	printf("     -t -T -u -U: run any combination of sendto (-t), write (-T), sendmsg (-u), sendmmsg (-U). default: all tests\n");
+	printf(" Listing options:\n");
+	for (i = 0; long_options[i].name != 0; i++) {
+		printf(" --%s", long_options[i].name);
+		if (long_options[i].flag != NULL)
+			printf("\t\t flag (internal value:%d)",
+			       *long_options[i].flag);
+		else
+			printf("\t\t short-option: -%c",
+			       long_options[i].val);
+		printf("\n");
+	}
+	printf("     -u -U -t -T: run any combination of sendmsg/sendmmsg/sendto/write\n");
+	printf("         default: all tests\n");
+	printf("\n");
+
 	return EXIT_FAIL_OPTION;
 }
 
@@ -322,25 +354,27 @@ int main(int argc, char *argv[])
 	char *dest_ip;
 	int run_flag = 0;
 	int batch = 32;
+	int longindex = 0;
 
 	/* Support for both IPv4 and IPv6 */
 	struct sockaddr_storage dest_addr; /* Can contain both sockaddr_in and sockaddr_in6 */
 	memset(&dest_addr, 0, sizeof(dest_addr));
 
 	/* Parse commands line args */
-	while ((c = getopt(argc, argv, "c:p:m:64v:tTuUb:")) != -1) {
+	while ((c = getopt_long(argc, argv, "hc:p:m:64v:tTuUb:",
+				long_options, &longindex)) != -1) {
 		if (c == 'c') count       = atoi(optarg);
 		if (c == 'p') dest_port   = atoi(optarg);
 		if (c == 'm') msg_sz      = atoi(optarg);
 		if (c == 'b') batch       = atoi(optarg);
 		if (c == '4') addr_family = AF_INET;
 		if (c == '6') addr_family = AF_INET6;
-		if (c == 'v') verbose     = atoi(optarg);
+		if (c == 'v') verbose     = optarg ? atoi(optarg) : 1;
 		if (c == 'u') run_flag   |= RUN_SENDMSG;
 		if (c == 'U') run_flag   |= RUN_SENDMMSG;
 		if (c == 't') run_flag   |= RUN_SENDTO;
 		if (c == 'T') run_flag   |= RUN_WRITE;
-		if (c == '?') return usage(argv);
+		if (c == 'h' || c == '?') return usage(argv);
 	}
 	if (optind >= argc) {
 		fprintf(stderr, "Expected dest IP-address (IPv6 or IPv4) argument after options\n");

--- a/src/udp_flood.c
+++ b/src/udp_flood.c
@@ -284,7 +284,7 @@ static void time_function(int sockfd, struct sockaddr_storage *dest_addr,
 	uint64_t time_begin, time_end, time_interval;
 	int cnt_send;
 	double pps, ns_per_pkt, timesec;
-	int tsc_cycles;
+	uint64_t tsc_cycles;
 
 	time_begin = gettime();
 	tsc_begin  = rdtsc();
@@ -307,10 +307,8 @@ static void time_function(int sockfd, struct sockaddr_storage *dest_addr,
 	tsc_cycles = tsc_interval / cnt_send;
 	ns_per_pkt = ((double)time_interval / cnt_send);
 	timesec    = ((double)time_interval / NANOSEC_PER_SEC);
-	printf(" - Per packet: %d cycles(tsc) %.2f ns, %.2f pps (time:%.2f sec)\n"
-	       "   (packet count:%d tsc_interval:%lu)\n",
-	       tsc_cycles, ns_per_pkt, pps, timesec,
-	       cnt_send, tsc_interval);
+	print_result(tsc_cycles, ns_per_pkt, pps, timesec,
+		     cnt_send, tsc_interval);
 }
 
 int main(int argc, char *argv[])
@@ -365,23 +363,25 @@ int main(int argc, char *argv[])
 	 */
 	Connect(sockfd, (struct sockaddr *)&dest_addr, sockaddr_len(&dest_addr));
 
+	if (!verbose)
+		printf("             \tns/pkt\tpps\t\ttsc_int\n");
 	if (run_flag & RUN_SENDTO) {
-		printf("\nPerformance of: sendto()\n");
+		print_header("sendto", 0);
 		time_function(sockfd, &dest_addr, count, msg_sz, flood_with_sendto);
 	}
 
 	if (run_flag & RUN_SENDMSG) {
-		printf("\nPerformance of: sendmsg()\n");
+		print_header("sendmsg", 0);
 		time_function(sockfd, &dest_addr, count, msg_sz, flood_with_sendmsg);
 	}
 
 	if (run_flag & RUN_SENDMMSG) {
-		printf("\nPerformance of: sendMmsg()\n");
+		print_header("sendMmsg", 32);
 		time_function(sockfd, &dest_addr, count, msg_sz, flood_with_sendMmsg);
 	}
 
 	if (run_flag & RUN_WRITE) {
-		printf("\nPerformance of: write()\n");
+		print_header("write", 0);
 		time_function(sockfd, &dest_addr, count, msg_sz, flood_with_write);
 	}
 

--- a/src/udp_sink.c
+++ b/src/udp_sink.c
@@ -320,14 +320,16 @@ int main(int argc, char *argv[])
 	int addr_family = AF_INET; /* Default address family */
 	uint16_t listen_port = 6666;
 	int run_flag = 0;
+	int batch = 32;
 
 	/* Support for both IPv4 and IPv6 */
 	struct sockaddr_storage listen_addr; /* Can contain both sockaddr_in and sockaddr_in6 */
 
 	/* Parse commands line args */
-	while ((c = getopt(argc, argv, "c:r:l:64sv:tTuU")) != -1) {
+	while ((c = getopt(argc, argv, "c:r:l:64sv:tTuUb:")) != -1) {
 		if (c == 'c') count       = atoi(optarg);
 		if (c == 'r') repeat      = atoi(optarg);
+		if (c == 'b') batch       = atoi(optarg);
 		if (c == 'l') listen_port = atoi(optarg);
 		if (c == '4') addr_family = AF_INET;
 		if (c == '6') addr_family = AF_INET6;
@@ -375,8 +377,8 @@ int main(int argc, char *argv[])
 	Bind(sockfd, &listen_addr);
 
 	if (run_flag & RUN_RECVMMSG) {
-		print_header("recvMmsg", 32);
-		time_function(sockfd, count, repeat, 32, sink_with_recvMmsg);
+		print_header("recvMmsg", batch);
+		time_function(sockfd, count, repeat, batch, sink_with_recvMmsg);
 	}
 
 	if (run_flag & RUN_RECVMSG) {


### PR DESCRIPTION
This patchset contains:
 - allow to choose a subset of the syscalls to test at runtime
 - write() for udp_flood, to make it more symetric with udp_sink
 - allow to choose the batch size for recvmmsg at runtime
 - new non-verbose output mode
 - long command-line options
 - and gitignore files