### PR TITLE
Changed printing of CPU ids to ensure numerical order

### DIFF
--- a/bin/softnet_stat.pl
+++ b/bin/softnet_stat.pl
@@ -174,7 +174,7 @@ sub difference($$) {
 	$sum{$key} = 0;
     }
 
-    my @cpus = (sort keys %$prev);
+    my @cpus = ( sort {$a <=> $b} (keys %$prev) );
     foreach my $cpu (@cpus) {
 	printf("CPU:%02d ", $cpu);
 


### PR DESCRIPTION
The previous code would print the CPU IDs in alphabetical order, not numerical order. So on machines with >9 CPUs, CPUs 10, 11, and so on would be listed before CPU 02.

Output before the patch:
```
CPU          total/sec     dropped/sec    squeezed/sec   collision/sec      rx_rps/sec  flow_limit/sec 
CPU:00               0               0               0               0               0               0 
CPU:01               0               0               0               0               0               0 
CPU:10               1               0               0               0               0               0 
CPU:11               0               0               0               0               0               0 
CPU:12               0               0               0               0               0               0 
CPU:13               0               0               0               0               0               0 
CPU:14               0               0               0               0               0               0 
CPU:15               0               0               0               0               0               0 
CPU:02              11               0               0               0               0               0 
CPU:03               0               0               0               0               0               0 
CPU:04               0               0               0               0               0               0 
CPU:05               0               0               0               0               0               0 
CPU:06               0               0               0               0               0               0 
CPU:07               0               0               0               0               0               0 
CPU:08               0               0               0               0               0               0 
CPU:09               0               0               0               0               0               0 

Summed:             12               0               0               0               0               0
```

Output after the patch:
```
CPU          total/sec     dropped/sec    squeezed/sec   collision/sec      rx_rps/sec  flow_limit/sec 
CPU:00               0               0               0               0               0               0 
CPU:01               0               0               0               0               0               0 
CPU:02              10               0               0               0               0               0 
CPU:03               0               0               0               0               0               0 
CPU:04               0               0               0               0               0               0 
CPU:05               0               0               0               0               0               0 
CPU:06               0               0               0               0               0               0 
CPU:07               0               0               0               0               0               0 
CPU:08               0               0               0               0               0               0 
CPU:09               0               0               0               0               0               0 
CPU:10               6               0               0               0               0               0 
CPU:11               1               0               0               0               0               0 
CPU:12               0               0               0               0               0               0 
CPU:13               0               0               0               0               0               0 
CPU:14               0               0               0               0               0               0 
CPU:15               0               0               0               0               0               0 

Summed:             17               0               0               0               0               0 
```

