### PR TITLE
Playing with generating XDP BPF tail-call graphviz

### DIFF
--- a/python/bpftool-collect-json.sh
+++ b/python/bpftool-collect-json.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# System wide collection of BPF maps and progs
+#  - Plus contents of individual prog_array "tail-call" maps
+#
+# This output can be parsed by other tools to generate
+#  - graph showing possible tail-calls interacting
+#
+
+export VERBOSE=yes
+
+## -- General shell logging cmds --
+function err() {
+    local exitcode=$1
+    shift
+    echo "ERROR: $@" >&2
+    exit $exitcode
+}
+
+function warn() {
+    echo "WARN : $@" >&2
+}
+
+function info() {
+    if [[ -n "$VERBOSE" ]]; then
+	echo "INFO : $@" >&2
+    fi
+}
+
+## -- General shell tricks --
+function root_check_run_with_sudo() {
+    # Trick so, program can be run as normal user, will just use "sudo"
+    #  call as root_check_run_as_sudo "$@"
+    if [ "$EUID" -ne 0 ]; then
+	if [ -x $0 ]; then # Directly executable use sudo
+	    info "Not root, running with sudo"
+            sudo "$0" "$@"
+            exit $?
+	fi
+	err 4 "cannot perform sudo run of $0"
+    fi
+}
+root_check_run_with_sudo "$@"
+
+export bpftool=$(which bpftool)
+if (( $? != 0 )); then
+    err 9 "Cannot find cmdline tool 'bpftool'"
+fi
+
+export jq=$(which jq)
+if (( $? != 0 )); then
+    err 9 "Cannot find cmdline tool 'bpftool'"
+fi
+
+info "Collecting: BPF-progs"
+$bpftool --json prog show > data-bpftool-prog.json
+
+info "Collecting: BPF-maps"
+$bpftool --json map show > data-bpftool-map.json
+
+info "Finding map types: prog_array"
+prog_array_ids=$($jq '.[] | select(.type == "prog_array") |.id' data-bpftool-map.json)
+info "[-] IDs" $prog_array_ids
+
+info "Collecting map contents from: prog_array"
+for ID in $prog_array_ids ; do
+    info "[+] Process ID:${ID}"
+    $bpftool --json map dump id $ID > data-prog_array_map_${ID}_contents.json
+done

--- a/python/xdp-tailcall-graphviz.py
+++ b/python/xdp-tailcall-graphviz.py
@@ -1,0 +1,90 @@
+# /// script
+# dependencies = ["graphviz"]
+# ///
+
+from pathlib import Path
+import graphviz
+import json
+
+
+bpf_progs = {}
+bpf_maps = {}
+
+"""
+This part of the code merges data from multiple files
+"""
+
+# Load bpf progs
+with open('out07.bpftool-prog-show') as file:
+	for prog in json.load(file):
+		# Skip bpf programs without a name
+		if 'name' not in prog:
+			continue
+
+		if 'map_ids' not in prog:
+			prog['map_ids'] = []
+
+		bpf_progs[prog['id']] = prog
+
+# Load bpf maps
+with open('out06.bpftool-map-show') as file:
+	for map in json.load(file):
+		if 'contents' not in map:
+			map['contents'] = []
+
+		bpf_maps[map['id']] = map
+
+# Load the prog_array map contents
+for map_id in bpf_maps:
+	filename = f'prog_array_map_{map_id}_contents.json'
+	if Path(filename).is_file():
+		with open(filename) as file:
+			prog_array_map_contents = json.load(file)
+
+			# Maps that no longer exist will return object with error
+			if not isinstance(prog_array_map_contents, list):
+				continue
+
+			bpf_maps[map_id]['contents'] = [item['formatted'] for item in prog_array_map_contents]
+
+"""
+This part of the code draws the graph
+"""
+
+dot = graphviz.Digraph(comment='BPF')
+
+for prog in bpf_progs.values():
+	# Skip drawing non-XDP programs unless they're referenced by an XDP program, I think?
+	if prog['type'] not in ['xdp']:
+		continue
+
+	# xdp_main don't seem to be connected to anything else
+	# skip to make graph more compact
+	if prog['name'] in ['xdp_main']:
+		continue
+
+	# Draw the prog node
+	dot.node(f'prog_{prog['id']}', f'{prog['name']} (prog_{prog['id']})', style='filled', fillcolor='#40e0d0')
+
+	# Draw references to bpf maps
+	for map_id in prog['map_ids']:
+		# Draw arrow from prog to each map in map_ids
+		dot.edge(f'prog_{prog['id']}', f'map_{map_id}')
+
+		if map_id not in bpf_maps:
+			# If we don't have extended info about the map, draw a box with text "<unknown>"
+			dot.node(f'map_{map_id}', f'<unknown> (map_{map_id})', style='filled', fillcolor=None, shape='box')
+		else:
+			map = bpf_maps[map_id]
+
+			# Draw a box with text containing the map type and id and color it pink if it's a prog_array
+			dot.node(f'map_{map_id}', f'{map['type']} (map_{map_id})', style='filled', fillcolor='#ff000042' if map['type'] == 'prog_array' else None, shape='box')
+
+			# Draw arrows from the prog_array map back to a prog
+			if map['type'] == 'prog_array':
+				for item in map['contents']:
+					dot.edge(f'map_{map_id}', f'prog_{item['value']}')
+
+print(dot.source)
+
+dot.view()

--- a/python/xdp-tailcall-graphviz.py
+++ b/python/xdp-tailcall-graphviz.py
@@ -15,7 +15,7 @@ This part of the code merges data from multiple files
 """
 
 # Load bpf progs
-with open('out07.bpftool-prog-show') as file:
+with open('data-bpftool-prog.json') as file:
 	for prog in json.load(file):
 		# Skip bpf programs without a name
 		if 'name' not in prog:
@@ -27,16 +27,19 @@ with open('out07.bpftool-prog-show') as file:
 		bpf_progs[prog['id']] = prog
 
 # Load bpf maps
-with open('out06.bpftool-map-show') as file:
+with open('data-bpftool-map.json') as file:
 	for map in json.load(file):
 		if 'contents' not in map:
 			map['contents'] = []
+
+		if 'name' not in map:
+			map['name'] = 'Unknown'
 
 		bpf_maps[map['id']] = map
 
 # Load the prog_array map contents
 for map_id in bpf_maps:
-	filename = f'prog_array_map_{map_id}_contents.json'
+	filename = f'data-prog_array_map_{map_id}_contents.json'
 	if Path(filename).is_file():
 		with open(filename) as file:
 			prog_array_map_contents = json.load(file)
@@ -54,36 +57,49 @@ This part of the code draws the graph
 dot = graphviz.Digraph(comment='BPF')
 
 for prog in bpf_progs.values():
-	# Skip drawing non-XDP programs unless they're referenced by an XDP program, I think?
+	# Skip drawing non-XDP programs
 	if prog['type'] not in ['xdp']:
 		continue
 
-	# xdp_main don't seem to be connected to anything else
-	# skip to make graph more compact
+	# skip 'xdp_main' as it belong to another service/product
 	if prog['name'] in ['xdp_main']:
 		continue
 
 	# Draw the prog node
-	dot.node(f'prog_{prog['id']}', f'{prog['name']} (prog_{prog['id']})', style='filled', fillcolor='#40e0d0')
+	dot.node(f"prog_{prog['id']}", f"{prog['name']}\n(prog_{prog['id']})", style='filled', fillcolor='#40e0d0')
 
 	# Draw references to bpf maps
 	for map_id in prog['map_ids']:
+
+		# Skip drawing other maps than 'prog_array'
+# not working...
+#		if map['type'] not in 'prog_array':
+#			continue;
+
 		# Draw arrow from prog to each map in map_ids
-		dot.edge(f'prog_{prog['id']}', f'map_{map_id}')
+		dot.edge(f'prog_{prog["id"]}', f'map_{map_id}')
 
 		if map_id not in bpf_maps:
 			# If we don't have extended info about the map, draw a box with text "<unknown>"
-			dot.node(f'map_{map_id}', f'<unknown> (map_{map_id})', style='filled', fillcolor=None, shape='box')
+			dot.node(f'map_{map_id}', f'<unknown> (map_{map_id})',
+				 style='filled', fillcolor=None, shape='box')
 		else:
 			map = bpf_maps[map_id]
+			print(map)
 
 			# Draw a box with text containing the map type and id and color it pink if it's a prog_array
-			dot.node(f'map_{map_id}', f'{map['type']} (map_{map_id})', style='filled', fillcolor='#ff000042' if map['type'] == 'prog_array' else None, shape='box')
+			dot.node(f'map_{map_id}', f"name:{map['name']}\n{map['type']}\n(map_{map_id})",
+				 style='filled', fillcolor='#ff000042' if map['type'] == 'prog_array' else None, shape='box')
+
+#			if map['type'] == 'prog_array':
+#				# Draw a box with text containing the map type
+#				dot.node(f'map_{map_id}', f"{map['type']} (map_{map_id})",
+#					 style='filled', fillcolor='#ff000042', shape='box')
 
 			# Draw arrows from the prog_array map back to a prog
 			if map['type'] == 'prog_array':
 				for item in map['contents']:
-					dot.edge(f'map_{map_id}', f'prog_{item['value']}')
+					dot.edge(f'map_{map_id}', f"prog_{item['value']}")
 
 print(dot.source)
 

--- a/python/xdp-tailcall-graphviz.py
+++ b/python/xdp-tailcall-graphviz.py
@@ -71,21 +71,20 @@ for prog in bpf_progs.values():
 	# Draw references to bpf maps
 	for map_id in prog['map_ids']:
 
-		# Skip drawing other maps than 'prog_array'
-# not working...
-#		if map['type'] not in 'prog_array':
-#			continue;
-
-		# Draw arrow from prog to each map in map_ids
-		dot.edge(f'prog_{prog["id"]}', f'map_{map_id}')
-
 		if map_id not in bpf_maps:
 			# If we don't have extended info about the map, draw a box with text "<unknown>"
 			dot.node(f'map_{map_id}', f'<unknown> (map_{map_id})',
 				 style='filled', fillcolor=None, shape='box')
 		else:
 			map = bpf_maps[map_id]
-			print(map)
+			# print(map)
+
+			# Skip drawing other maps than 'prog_array'
+			if map['type'] not in ['prog_array']:
+				continue;
+
+			# Draw arrow from prog to each map in map_ids
+			dot.edge(f'prog_{prog["id"]}', f'map_{map_id}')
 
 			# Draw a box with text containing the map type and id and color it pink if it's a prog_array
 			dot.node(f'map_{map_id}', f"name:{map['name']}\n{map['type']}\n(map_{map_id})",

--- a/python/xdp-tailcall-graphviz.py
+++ b/python/xdp-tailcall-graphviz.py
@@ -1,11 +1,9 @@
-# /// script
+#!/usr/bin/env python3
 # dependencies = ["graphviz"]
-# ///
-
+#
 from pathlib import Path
 import graphviz
 import json
-
 
 bpf_progs = {}
 bpf_maps = {}
@@ -77,7 +75,6 @@ for prog in bpf_progs.values():
 				 style='filled', fillcolor=None, shape='box')
 		else:
 			map = bpf_maps[map_id]
-			# print(map)
 
 			# Skip drawing other maps than 'prog_array'
 			if map['type'] not in ['prog_array']:
@@ -89,11 +86,6 @@ for prog in bpf_progs.values():
 			# Draw a box with text containing the map type and id and color it pink if it's a prog_array
 			dot.node(f'map_{map_id}', f"name:{map['name']}\n{map['type']}\n(map_{map_id})",
 				 style='filled', fillcolor='#ff000042' if map['type'] == 'prog_array' else None, shape='box')
-
-#			if map['type'] == 'prog_array':
-#				# Draw a box with text containing the map type
-#				dot.node(f'map_{map_id}', f"{map['type']} (map_{map_id})",
-#					 style='filled', fillcolor='#ff000042', shape='box')
 
 			# Draw arrows from the prog_array map back to a prog
 			if map['type'] == 'prog_array':


### PR DESCRIPTION
One technique for sharing the single XDP BPF-hook is via tail-calls

- via map type `prog_array` that can contain other BPF-progs

Here we try to get an overview of how these BPF-progs can jump/call each-other

- via dumping JSON via bpftool
- and parsing this via Python
- that outputs a graphviz drawing of the connections
