### PR TITLE
vhost-tap-overload: benchmark that via vhost_net overloads a tap device

### DIFF
--- a/vhost-tap-overload/Makefile
+++ b/vhost-tap-overload/Makefile
@@ -1,0 +1,5 @@
+.PHONY: all
+
+all:
+	clang -Wall -Wextra -I/usr/include/libnl3 -O2 -g main.c vhost.c tap.c -o vhost \
+		$(shell pkg-config --cflags --libs libnl-3.0 libnl-route-3.0)

--- a/vhost-tap-overload/common.h
+++ b/vhost-tap-overload/common.h
@@ -45,7 +45,7 @@ struct virtio_net_hdr {
 int tap_open(const char *usr_tap_name, char *new_tap_name, size_t new_tap_name_sz, uint32_t ifr_extra_flags);
 
 int tap_set_offloads(int tap_fd);
-int tap_bring_up(int tap_fd);
+int tap_bring_up(int tap_fd, int txqlen);
 int tap_get_src_mac(int tap_fd, uint8_t src_mac[6]);
 
 
@@ -58,7 +58,7 @@ struct vring_split* vring_split_new(uint16_t num, int bufs_device_readable);
 void vhost_setup_vring_split(int vhost_fd, uint16_t index, struct vring_split *vring, int tap_fd);
 
 int vring_desc_put(struct vring_split *vring, struct iovec *iov, int iov_cnt, int *id_ptr);
-void vring_kick(struct vring_split *vring, int cnt);
+void vring_kick(struct vring_split *vring);
 
 int vring_callfd(struct vring_split *vring);
 int vring_errfd(struct vring_split *vring);

--- a/vhost-tap-overload/common.h
+++ b/vhost-tap-overload/common.h
@@ -1,0 +1,86 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <sys/uio.h>
+
+
+
+/* All is little-endian */
+struct virtio_net_hdr {
+#define VIRTIO_NET_HDR_F_NEEDS_CSUM	1	/* Use csum_start, csum_offset */
+#define VIRTIO_NET_HDR_F_DATA_VALID	2	/* Csum is valid */
+#define VIRTIO_NET_HDR_F_RSC_INFO	4
+	uint8_t flags;
+#define VIRTIO_NET_HDR_GSO_NONE		0	/* Not a GSO frame */
+#define VIRTIO_NET_HDR_GSO_TCPV4	1	/* GSO frame, IPv4 TCP (TSO) */
+#define VIRTIO_NET_HDR_GSO_UDP		3	/* GSO frame, IPv4 UDP (UFO) */
+#define VIRTIO_NET_HDR_GSO_TCPV6	4	/* GSO frame, IPv6 TCP */
+#define VIRTIO_NET_HDR_GSO_UDP_L4	5
+#define VIRTIO_NET_HDR_GSO_ECN		0x80	/* TCP has ECN set */
+	uint8_t gso_type;
+	uint16_t hdr_len;		/* Ethernet + IP + tcp/udp hdrs */
+	uint16_t gso_size;		/* Bytes to append to hdr_len per frame */
+        uint16_t csum_start;		/* Position to start checksumming from */
+	uint16_t csum_offset;		/* Offset after that to place checksum */
+	uint16_t num_buffers;		/* Number of merged rx buffers */
+#if 0
+	uint32_t hash_value;		/* (Only if VIRTIO_NET_F_HASH_REPORT negotiated) */
+	uint16_t hash_report;		/* (Only if VIRTIO_NET_F_HASH_REPORT negotiated) */
+        uint16_t padding_reserved;	/* (Only if VIRTIO_NET_F_HASH_REPORT negotiated) */
+#endif
+};
+
+/* The device uses this in used->flags to advise the driver: don’t kick me 
+ * when you add a buffer.  It’s unreliable, so it’s simply an 
+ * optimization. */
+#define VIRTQ_USED_F_NO_NOTIFY  1
+
+/* The driver uses this in avail->flags to advise the device: don't
+* interrupt me when you consume a buffer. It's unreliable, so it's
+* simply an optimization. */
+#define VIRTQ_AVAIL_F_NO_INTERRUPT 1
+
+
+/* tap.c */
+
+int tap_open(const char *usr_tap_name, char *new_tap_name, size_t new_tap_name_sz, uint32_t ifr_extra_flags);
+
+int tap_set_offloads(int tap_fd);
+int tap_bring_up(int tap_fd);
+int tap_get_src_mac(int tap_fd, uint8_t src_mac[6]);
+
+
+/* vhost.c */
+int vhost_open();
+void vhost_set_mem_table(int vhost_fd, struct iovec *iov, ssize_t iov_cnt);
+
+struct vring_split* vring_split_new(uint16_t num, int bufs_device_readable);
+
+void vhost_setup_vring_split(int vhost_fd, uint16_t index, struct vring_split *vring, int tap_fd);
+
+int vring_desc_put(struct vring_split *vring, struct iovec *iov, int iov_cnt, int *id_ptr);
+void vring_kick(struct vring_split *vring, int cnt);
+
+int vring_callfd(struct vring_split *vring);
+int vring_errfd(struct vring_split *vring);
+
+int vring_get_buf(struct vring_split *vring, uint8_t **buf_ptr, unsigned int *len, int *id_ptr);
+
+int vring_recycle_id(struct vring_split *vring, int id);
+void vring_print_id(struct vring_split *vring, uint32_t id);
+
+void vring_set_suppress_notifications(struct vring_split *vring);
+int vring_clear_suppress_notifications(struct vring_split *vring);
+int vring_get_buf2(struct vring_split *vring, uint32_t *id_ptr, uint32_t *len_ptr);
+void vring_recycle_bump(struct vring_split *vring, uint16_t d);
+
+int vring_is_empty(struct vring_split *vring);
+
+struct virtq_used_elem {
+	uint32_t id;  /* Index of start of used descriptor chain. le32
+		       * for padding reasons */
+	uint32_t len; /* Total length of the descriptor chain which
+		       * was written to. */
+} __attribute__((packed));
+
+int vring_get_buf_bulk(struct vring_split *vring, struct virtq_used_elem *le, int le_sz);
+int vring_recycle_bulk(struct vring_split *vring, struct virtq_used_elem *le, uint16_t le_cnt);

--- a/vhost-tap-overload/main.c
+++ b/vhost-tap-overload/main.c
@@ -1,0 +1,337 @@
+#include <linux/if_tun.h>
+#include <errno.h>
+#include <sys/epoll.h>
+#include <error.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <netlink/netlink.h>
+#include <netlink/route/link.h>
+#include <netlink/route/link/inet.h>
+#include <netlink/route/nexthop.h>
+#include <netlink/route/route.h>
+#include <netlink/socket.h>
+
+#include "common.h"
+
+uint64_t realtime_now(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+int hex_dump(char *desc, void *addr, int len)
+{
+	const char hex[] = "0123456789abcdef";
+	int i, lines = 0;
+	char line[128];
+	memset(line, ' ', 128);
+	uint8_t *pc = (uint8_t *)addr;
+
+	if (desc != NULL) {
+		printf("%s:\n", desc);
+	}
+
+	for (i = 0; i < len; i++) {
+		if ((i % 16) == 0) {
+			if (i != 0) {
+				printf("%.*s\n", 128, line);
+				lines++;
+			}
+			snprintf(line, 128, "  0x%04x: ", i);
+		}
+
+		line[10 + (i % 16) * 3 + 0] = hex[(pc[i] >> 4) & 0xf];
+		line[10 + (i % 16) * 3 + 1] = hex[pc[i] & 0xf];
+
+		if ((pc[i] < 0x20) || (pc[i] > 0x7e)) {
+			line[59 + (i % 16)] = '.';
+		} else {
+			line[59 + (i % 16)] = pc[i];
+		}
+	}
+
+	while ((i % 16) != 0) {
+		line[10 + (i % 16) * 3 + 0] = ' ';
+		line[10 + (i % 16) * 3 + 1] = ' ';
+		line[59 + (i % 16)] = ' ';
+		i++;
+	}
+
+	printf("%.*s\n", 128, line);
+	lines++;
+	return lines;
+}
+
+void add_route(int family, char *subnet, char *ifname)
+{
+	struct nl_sock *sock = nl_socket_alloc();
+	nl_connect(sock, NETLINK_ROUTE);
+
+	struct nl_cache *link_cache;
+	struct rtnl_link *link;
+
+	// Get link index for tap0
+	rtnl_link_alloc_cache(sock, AF_UNSPEC, &link_cache);
+	link = rtnl_link_get_by_name(link_cache, ifname);
+	int ifindex = rtnl_link_get_ifindex(link);
+
+	// Build route
+	struct rtnl_route *route = rtnl_route_alloc();
+	struct nl_addr *dst;
+	nl_addr_parse(subnet, family, &dst);
+	rtnl_route_set_dst(route, dst);
+	rtnl_route_set_table(route, RT_TABLE_MAIN);
+
+	struct rtnl_nexthop *nh = rtnl_route_nh_alloc();
+	rtnl_route_nh_set_ifindex(nh, ifindex);
+	rtnl_route_add_nexthop(route, nh);
+
+	// Add route
+	rtnl_route_add(sock, route, 0);
+
+	// Cleanup
+	rtnl_route_put(route);
+	nl_addr_put(dst);
+	rtnl_link_put(link);
+	nl_cache_free(link_cache);
+	nl_socket_free(sock);
+}
+
+/* to get good perf on TX we want VIRTIO_F_NOTIFY_ON_EMPTY. Otherwise,
+ * we'll get plenty of notifications, even when using
+ * VIRTQ_AVAIL_F_NO_INTERRUPT.  With NOTIFY_ON_EMPTY we only get event
+ * when the flush is complete, which is rarer. */
+
+#define PACKETS 512
+int main()
+{
+	char tap_name[16];
+	int tap_fd = tap_open("tap0", tap_name, sizeof(tap_name), IFF_NAPI );
+	printf("[ ] Tap tunnel name: %s\n", tap_name);
+	tap_bring_up(tap_fd);
+
+	tap_set_offloads(tap_fd);
+
+	int vhost_fd = vhost_open();
+
+	char *buf_rx = calloc(1, PACKETS * 2048);
+	char *buf_tx = calloc(1, PACKETS * 2048);
+	struct iovec iov[] = {{.iov_base = buf_rx, .iov_len = 2048*PACKETS},
+			      {.iov_base = buf_tx, .iov_len = 2048 * PACKETS}};
+
+	uint8_t mac[6] = {0xce, 0xdd, 0xba, 0x1f, 0x50, 0x82};
+	// tap_get_src_mac(tap_fd, mac);
+	printf("MAC address of tap0: %02x:%02x:%02x:%02x:%02x:%02x\n", mac[0], mac[1],
+	       mac[2], mac[3], mac[4], mac[5]);
+
+	add_route(AF_INET, "10.10.10.0/24", "tap0");
+	vhost_set_mem_table(vhost_fd, iov, 2);
+
+	struct vring_split *vrings[2];
+	vrings[0] = vring_split_new(PACKETS*4, 0);
+	vrings[1] = vring_split_new(PACKETS*4, 1);
+
+
+	vhost_setup_vring_split(vhost_fd, 0, vrings[0], tap_fd);
+	vhost_setup_vring_split(vhost_fd, 1, vrings[1], tap_fd);
+
+	// RX
+	{
+		vring_recycle_bump(vrings[0], 0); // must be zero here
+		int id;
+		int i;
+		int pkts_rx = PACKETS/2 -1;
+		for (i=0; i<pkts_rx; i++) {
+			vring_desc_put(vrings[0],
+				       &(struct iovec){.iov_base = buf_rx + 2048*i, .iov_len = 2048}, 1,
+				       &id);
+			//vring_print_id(vrings[0], id);
+		}
+		vring_kick(vrings[0], pkts_rx);
+	}
+
+
+	// TX
+	uint8_t payload[] =
+		"\xff\xff\xff\xff\xff\xff" // Destination MAC
+		"\x00\x00\x22\x33\x44\x55" // Source MAC
+		"\x08\x00"		   // EtherType: IPv4
+		"\x45\x00\x00\xc0\xa0\xa7\x40\x00\x40\x11\xd9\x5f\x0a\x0a\x0a\x0a"
+		"\xac\x11\x00\x01\xac\x60\x11\x51\x00\xac\xca\xb2\x5a\x01\x00\xa1"
+		"\xf7\x4c\x9c\x5e\xc0\x19\x31\x6d\xf7\x4c\x9c\xff\xc2\x65\x07\x34"
+		"\x8b\xd0\x6f\x8f\x02\xb3\x98\x4e\x05\x32\xc7\xbe\xf6\xbc\xf9\xeb"
+		"\xc4\x7e\x35\xd4\x77\x49\xb5\xf6\xce\xb0\x77\x36\x3a\xc0\xfa\x98"
+		"\x16\x48\x18\x1f\x7d\x96\xa8\x7a\xc9\x26\xa8\x02\x92\xb0\xdb\xdc"
+		"\x4d\x7d\x0b\xb1\x87\xea\x26\x1f\x10\xa1\x51\xfc\xfe\x2d\xf8\xff"
+		"\x67\x95\xaf\xff\x55\xc9\xa9\xfe\xac\xf3\x09\x49\x01\x31\x6d\xf7"
+		"\x4c\x9c\x5e\xc0\x19\x31\x6d\xf7\x4c\x9c\xff\xc2\x65\x07\x34\x8b"
+		"\xea\x67\xcf\x82\x66\xfc\xcd\x27\x83\x5b\x3b\x76\x59\xc2\x1e\x35"
+		"\x6a\x8b\x83\x37\xda\xf8\xa4\xe2\xa6\x92\xff\xb2\x3e\xfa\xb3\x45"
+		"\x43\xdb\x8a\xf4\x02\xce\x59\x76\xf2\x0c\x30\xb4\x7e\x52\x6f\x25";
+
+	struct virtio_net_hdr hdr = {
+		.flags = VIRTIO_NET_HDR_F_NEEDS_CSUM,
+		.hdr_len = 14 + 20 + 8,
+		.num_buffers = 0,
+		.csum_offset = 6,
+		.csum_start = 14 + 20,
+	};
+
+	int tx_size = 12 + sizeof(payload) + 1024;
+
+	uint64_t t0;
+	if (1) {
+		int pkts_tx = PACKETS;
+		vring_recycle_bump(vrings[1],pkts_tx/2);
+		int off;
+		for (off = 0; off < 1024 * pkts_tx; off += 1024) {
+			memcpy(buf_tx + off, &hdr, sizeof(hdr));
+			memcpy(buf_tx + off + 12, payload, sizeof(payload));
+			memcpy(buf_tx + off + 12 + 6, mac, 6);
+			memcpy(buf_tx + off + 12 + 0, mac, 6);
+			int id;
+			vring_desc_put(
+				vrings[1],
+				&(struct iovec){.iov_base = buf_tx + off, .iov_len = tx_size}, 1,
+				&id);
+			// vring_print_id(vrings[1], id);
+		}
+		t0 = realtime_now();
+		vring_kick(vrings[1],pkts_tx);
+	}
+	// Always suppressed for TX
+	//vring_set_suppress_notifications(vrings[1]);
+
+
+	int call[2];
+	int errfd[2];
+	call[0] = vring_callfd(vrings[0]);
+	call[1] = vring_callfd(vrings[1]);
+	errfd[0] = vring_errfd(vrings[0]);
+	errfd[1] = vring_errfd(vrings[1]);
+
+	int epfd = epoll_create1(0);
+	if (epfd == -1) {
+		error(-1, errno, "epoll_create1");
+	}
+
+	int fds[] = { call[0], call[1], errfd[0], errfd[1] };
+	for (int i = 0; i < 4; ++i) {
+		struct epoll_event ev = {
+			.events = EPOLLIN,
+			.data.fd = fds[i],
+		};
+		if (epoll_ctl(epfd, EPOLL_CTL_ADD, fds[i], &ev) == -1) {
+			error(-1, errno, "epoll_ctl");
+		}
+	}
+
+
+	uint64_t rx_counter = 0;
+	uint64_t rx_wakeup = 0;
+	uint64_t tx_counter = 0;
+	uint64_t tx_wakeup = 0;
+	//uint64_t xt0 = realtime_now();
+	while (1) {
+		// vring_print_id(vrings[0],0);
+		// vring_print_id(vrings[1],0);
+		if (realtime_now() - t0 > 1000000000ULL) {
+			double td = (realtime_now() - t0) / 1000000000ULL;
+			t0 = realtime_now();
+			if (1 || tx_counter == 0) {
+				printf("*rx* ");
+				vring_kick(vrings[0], -1);
+				printf("*tx* ");
+				vring_kick(vrings[1], -1);
+				printf("| ");
+			}
+
+
+			printf("rx=%.3f kpps / %.1fppw", rx_counter / 1000. / td, rx_counter * 1.0/rx_wakeup);
+			printf("  tx=%.3f kpps / %.1fppw\n", tx_counter / 1000. / td, tx_counter*1.0 / tx_wakeup);
+			rx_counter = 0;
+			rx_wakeup = 0;
+			tx_counter = 0;
+			tx_wakeup = 0;
+		}
+		// unsigned int len = -1;
+		//int r;
+
+		struct epoll_event events[4];
+		int nfds = epoll_wait(epfd, events, 4, 1000);
+		if (nfds == -1) {
+			if (errno == EAGAIN || errno == EINTR) continue;
+			error(-1, errno, "epoll_wait");
+		}
+
+		/* fd_set rfds; */
+		/* FD_ZERO(&rfds); */
+		/* FD_SET(call[0], &rfds); */
+		/* FD_SET(call[1], &rfds); */
+		/* FD_SET(errfd[0], &rfds); */
+		/* FD_SET(errfd[1], &rfds); */
+
+		/* select(errfd[1] + 1, &rfds, NULL, NULL, &(struct timeval){.tv_sec = 1}); */
+		// nanosleep(&(struct timespec){.tv_nsec=100}, NULL);
+		struct virtq_used_elem pkts[PACKETS];
+		uint64_t val;
+		for (int ii = 0; ii < nfds; ++ii) {
+		if (events[ii].data.fd == call[0]) {
+			rx_wakeup++;
+			//vring_set_suppress_notifications(vrings[0]);
+			read(call[0], &val, sizeof(val));
+
+			int idx = vring_get_buf_bulk(vrings[0], pkts, PACKETS);
+			rx_counter += idx;
+
+			//vring_recycle_bump(vrings[0], idx);
+			int needs_kick = vring_recycle_bulk(vrings[0], pkts, idx);
+			if (1|| needs_kick) {
+//				printf("kick rx\n");
+				vring_kick(vrings[0], 0);
+			}
+		}
+
+		if (events[ii].data.fd == call[1]) {
+			tx_wakeup ++;
+			read(call[1], &val, sizeof(val));
+
+			while (1) {
+			int needs_kick = 0;
+				int idx = vring_get_buf_bulk(vrings[1], pkts, PACKETS);
+				if (idx == 0)
+					break;
+				tx_counter += idx;
+
+				// printf("tx rx num=%d\n", idx);
+				//vring_recycle_bump(vrings[1], idx);
+				needs_kick = vring_recycle_bulk(vrings[1], pkts, idx);
+			
+//				nanosleep(&(struct timespec){.tv_nsec=100000}, NULL);
+
+			if (needs_kick){
+				//printf("td=%.3fms\n", (realtime_now() - xt0)/1000000.);
+				vring_kick(vrings[1], 0);
+				//printf("tx kick\n");
+			}
+			}
+		}
+		if (events[ii].data.fd == errfd[0]) {
+			read(errfd[0], &val, sizeof(val));
+			error(-1, ECOMM, "Mem error reported on RX queue");
+		}
+		if (events[ii].data.fd == errfd[1]) {
+			read(errfd[1], &val, sizeof(val));
+			error(-1, ECOMM, "Mem error reported on TX queue");
+		}
+		}
+	}
+
+	return 0;
+}

--- a/vhost-tap-overload/tap.c
+++ b/vhost-tap-overload/tap.c
@@ -1,0 +1,211 @@
+#include <string.h>
+#include <error.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+#include <sched.h>
+
+#include "common.h"
+
+#define MIN(x,y) ({ \
+    typeof(x) _x = (x);     \
+    typeof(y) _y = (y);     \
+    (void) (&_x == &_y);    \
+    _x <= _y ? _x : _y; })
+
+int tap_open(const char *usr_tap_name, char *new_tap_name, size_t new_tap_name_sz, uint32_t ifr_extra_flags){
+	int auto_delete = 1;
+	const char *tap_name = "\x00";
+
+	if (usr_tap_name && strlen(usr_tap_name)>0) {
+		tap_name = usr_tap_name;
+		auto_delete = 0;
+	}
+
+	/* First, whatever you do, the device /dev/net/tun must be
+	 * opened read/write. That device is also called the clone
+	 * device, because it's used as a starting point for the
+	 * creation of any tun/tap virtual interface. */
+	char *clone_dev_name = "/dev/net/tun";
+	int tap_fd  = open(clone_dev_name, O_RDWR | O_CLOEXEC | O_NONBLOCK);
+	if (tap_fd < 0) {
+		error(-1, errno, "open(%s)", clone_dev_name);
+	}
+
+	/* CAP_NET_ADMIN */
+	struct ifreq ifr = {};
+	memcpy(ifr.ifr_name, tap_name, MIN(IFNAMSIZ, (int)strlen(tap_name)));
+	ifr.ifr_flags = IFF_TAP | IFF_NO_PI | IFF_VNET_HDR | ifr_extra_flags;
+	int r = ioctl(tap_fd, TUNSETIFF, &ifr);
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNSETIFF)");
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	r = ioctl(tap_fd, TUNGETIFF, &ifr);
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNGETIFF)");
+	}
+
+	if (new_tap_name) {
+		snprintf(new_tap_name, new_tap_name_sz,"%.*s", IFNAMSIZ, ifr.ifr_name);
+	}
+
+	if (auto_delete == 1) {
+		ioctl(tap_fd, TUNSETPERSIST, 0);
+	}
+
+	/* I've had bad luck setting this to value other than the one
+	 * supported by the kernel (typically 12 bytes). */
+
+	int len = 0;
+	r = ioctl(tap_fd, TUNGETVNETHDRSZ, &len);
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNSETVNETHDRSZ)");
+	}
+
+	printf("len=%d\n", len);
+	len=12;
+	r = ioctl(tap_fd, TUNSETVNETHDRSZ, &(int){len});
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNSETVNETHDRSZ)");
+	}
+
+	return tap_fd;
+}
+
+#ifndef TUN_F_USO4
+#  define TUN_F_USO4 0x20
+#endif
+#ifndef TUN_F_USO6
+#  define TUN_F_USO6 0x40
+#endif
+
+int tap_set_offloads(int tap_fd)
+{
+
+	unsigned off_flags = TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6;
+	int r = ioctl(tap_fd, TUNSETOFFLOAD, off_flags);
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNSETOFFLOAD) - failed to set standard offloads CSUM TSO4 and TSO6");
+	}
+
+	/* Must set USO4 and USO6 at the same time. */
+	off_flags |=  TUN_F_USO4 | TUN_F_USO6;
+	r = ioctl(tap_fd, TUNSETOFFLOAD, off_flags);
+	if (r != 0) {
+		error(-1, errno, "ioctl(TUNSETOFFLOAD) - failed to set new offloads USO4 and USO6. Are you running kernel 6.2+?");
+	}
+	return 0;
+}
+
+int tap_attach_queue(int tap_fd)
+{
+	int r = ioctl(tap_fd, TUNSETQUEUE, &(struct ifreq){
+			.ifr_flags = IFF_ATTACH_QUEUE
+		});
+	if (r != 0) {
+		error(-1, errno, "TUNSETQUEUE/IFF_ATTACH_QUEUE");
+	}
+	return 0;
+}
+
+int tap_detach_queue(int tap_fd)
+{
+	int r = ioctl(tap_fd, TUNSETQUEUE, &(struct ifreq){
+			.ifr_flags = IFF_DETACH_QUEUE
+		});
+	if (r != 0) {
+		error(-1, errno, "TUNSETQUEUE/IFF_DETACH_QUEUE");
+	}
+	return 0;
+}
+
+int tap_bring_up(int tap_fd) {
+	struct ifreq ifr;
+	memset(&ifr, 0, sizeof(ifr));
+
+	if (ioctl(tap_fd, TUNGETIFF, &ifr) < 0) {
+		error(-1, errno, "TUNGETIFF");
+	}
+
+	int sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock < 0) {
+		error(-1, errno, "socket");
+	}
+
+	if (0) {
+		/* memset(&ifr, 0, sizeof(ifr)); */
+		/* strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1); */
+		ifr.ifr_qlen = 1024;
+
+		if (ioctl(sock, SIOCSIFTXQLEN, &ifr) < 0) {
+			error(errno, -1, "ioctl SIOCSIFTXQLEN");
+		}
+	}
+	
+	// Get current flags
+	if (ioctl(sock, SIOCGIFFLAGS, &ifr) < 0) {
+		error(-1, errno, "SIOCGIFFLAGS");
+	}
+
+	// Set interface up
+	ifr.ifr_flags |= IFF_UP;
+	if (ioctl(sock, SIOCSIFFLAGS, &ifr) < 0) {
+		error(-1, errno, "SIOCSIFFLAGS");
+	}
+
+	int i;
+	for (i=0; i<40; i++) {
+		sched_yield();
+		nanosleep(&(struct timespec){.tv_nsec=1000ULL}, NULL);
+	}
+
+	if (1) {
+		system("tc qdisc add dev tap0 ingress");
+		system("tc filter add dev tap0 ingress protocol ip u32 match ip dst 172.17.0.1/32      action  mirred egress redirect dev tap0");
+		system("tc qdisc add dev tap0 root netem delay 1ms 1ms");
+	}
+	close(sock);
+	return 0;
+}
+
+int tap_get_src_mac(int tap_fd, uint8_t src_mac[6]) {
+	struct ifreq ifr;
+	memset(&ifr, 0, sizeof(ifr));
+
+	if (ioctl(tap_fd, TUNGETIFF, &ifr) < 0) {
+		error(-1, errno, "TUNGETIFF");
+	}
+
+	char ifname[IFNAMSIZ];
+	strncpy(ifname, ifr.ifr_name, IFNAMSIZ);
+	printf("ifrname %s\n", ifname);
+
+	// Prepare ifr again with just the interface name
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+	
+
+	int sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock < 0) {
+		error(-1, errno, "socket");
+	}
+
+	// Get current flags
+        int r = ioctl(sock, SIOCGIFHWADDR, &ifr);
+	if (r<0) {
+		error(-1, errno, "SIOCGIFHWADDR");
+	}
+
+	memcpy(src_mac, ifr.ifr_hwaddr.sa_data, 6);
+	printf("mac %02x %02x\n", src_mac[0], src_mac[1]);
+	close(sock);
+	return 0;
+}

--- a/vhost-tap-overload/tap.c
+++ b/vhost-tap-overload/tap.c
@@ -170,7 +170,7 @@ int tap_bring_up(int tap_fd) {
 	if (1) {
 		system("tc qdisc add dev tap0 ingress");
 		system("tc filter add dev tap0 ingress protocol ip u32 match ip dst 172.17.0.1/32      action  mirred egress redirect dev tap0");
-		system("tc qdisc add dev tap0 root netem delay 1ms 1ms");
+		// system("tc qdisc add dev tap0 root netem delay 1ms 1ms");
 	}
 	close(sock);
 	return 0;

--- a/vhost-tap-overload/tap.c
+++ b/vhost-tap-overload/tap.c
@@ -127,7 +127,7 @@ int tap_detach_queue(int tap_fd)
 	return 0;
 }
 
-int tap_bring_up(int tap_fd) {
+int tap_bring_up(int tap_fd, int txqlen) {
 	struct ifreq ifr;
 	memset(&ifr, 0, sizeof(ifr));
 
@@ -140,10 +140,8 @@ int tap_bring_up(int tap_fd) {
 		error(-1, errno, "socket");
 	}
 
-	if (0) {
-		/* memset(&ifr, 0, sizeof(ifr)); */
-		/* strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1); */
-		ifr.ifr_qlen = 1024;
+	if (txqlen) {
+		ifr.ifr_qlen = txqlen;
 
 		if (ioctl(sock, SIOCSIFTXQLEN, &ifr) < 0) {
 			error(errno, -1, "ioctl SIOCSIFTXQLEN");
@@ -192,7 +190,6 @@ int tap_get_src_mac(int tap_fd, uint8_t src_mac[6]) {
 	// Prepare ifr again with just the interface name
 	memset(&ifr, 0, sizeof(ifr));
 	strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
-	
 
 	int sock = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sock < 0) {

--- a/vhost-tap-overload/tap.c
+++ b/vhost-tap-overload/tap.c
@@ -171,6 +171,7 @@ int tap_bring_up(int tap_fd) {
 		system("tc qdisc add dev tap0 ingress");
 		system("tc filter add dev tap0 ingress protocol ip u32 match ip dst 172.17.0.1/32      action  mirred egress redirect dev tap0");
 		// system("tc qdisc add dev tap0 root netem delay 1ms 1ms");
+		system("echo 1 > /sys/class/net/tap0/threaded ");
 	}
 	close(sock);
 	return 0;

--- a/vhost-tap-overload/vhost.c
+++ b/vhost-tap-overload/vhost.c
@@ -1,0 +1,572 @@
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <linux/vhost.h>
+
+#include "common.h"
+
+#ifndef VIRTIO_NET_F_MRG_RXBUF
+#define VIRTIO_NET_F_MRG_RXBUF 15
+#endif
+#ifndef VIRTIO_F_RING_RESET
+#define VIRTIO_F_RING_RESET 40
+#endif
+
+#define DO_EVENT_IDX 1
+
+int vhost_open()
+{
+	int vhost_fd = open("/dev/vhost-net", O_RDWR);
+	if (vhost_fd < 0) {
+		error(-1, errno, "open(/dev/vhost-net)");
+	}
+
+	/* Set current process as the (exclusive) owner of this file
+	 * descriptor.  This must be called before any other vhost
+	 * command.  Further calls to VHOST_OWNER_SET fail until
+	 * VHOST_OWNER_RESET is called. */
+	int r = ioctl(vhost_fd, VHOST_SET_OWNER, NULL);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_OWNER)");
+	}
+
+	uint64_t features = 0;
+	r = ioctl(vhost_fd, VHOST_GET_FEATURES, &features);
+	if (r < 0) {
+		error(-1, errno, "ioctl(VHOST_GET_FEATURES)");
+	}
+
+	uint64_t known_features = 0;
+
+#define PRINT_FEATURE(f)                                                                 \
+	if (features & (1ULL << f)) {                                                    \
+		known_features |= 1ULL << f;                                             \
+		printf(" " #f);                                                          \
+	}
+
+	printf("Vhost features: ");
+
+	PRINT_FEATURE(VIRTIO_F_NOTIFY_ON_EMPTY);
+	PRINT_FEATURE(VIRTIO_RING_F_INDIRECT_DESC);
+	PRINT_FEATURE(VIRTIO_RING_F_EVENT_IDX);
+	PRINT_FEATURE(VHOST_F_LOG_ALL);
+	PRINT_FEATURE(VIRTIO_F_ANY_LAYOUT);
+	PRINT_FEATURE(VIRTIO_F_VERSION_1);
+
+	PRINT_FEATURE(VHOST_NET_F_VIRTIO_NET_HDR);
+	PRINT_FEATURE(VIRTIO_NET_F_MRG_RXBUF);
+	PRINT_FEATURE(VIRTIO_F_ACCESS_PLATFORM);
+	PRINT_FEATURE(VIRTIO_F_RING_RESET);
+
+	if (~known_features & features) {
+		printf(" UNKNOWN:0x%lx", ~known_features & features);
+	}
+	printf("\n");
+
+	uint64_t our_features = (0
+				 //		| (1ULL << VIRTIO_RING_F_INDIRECT_DESC)
+				 | (1ULL << VIRTIO_F_VERSION_1)
+				 //		| (1ULL << VIRTIO_F_ACCESS_PLATFORM)
+				 //		| (1ULL << VHOST_NET_F_VIRTIO_NET_HDR)
+				 //		| (1ULL << VIRTIO_F_ANY_LAYOUT)
+	);
+
+	if (DO_EVENT_IDX) {
+		our_features |= (1ULL << VIRTIO_RING_F_EVENT_IDX);
+	} else {
+		our_features |= (1ULL << VIRTIO_F_NOTIFY_ON_EMPTY);
+	}
+
+	r = ioctl(vhost_fd, VHOST_SET_FEATURES, &our_features);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_FEATURES)");
+	}
+
+	features = 0;
+	r = ioctl(vhost_fd, VHOST_GET_BACKEND_FEATURES, &features);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_GET_BACKEND_FEATURES)");
+	}
+
+	printf("Vhost backend features: ");
+
+	PRINT_FEATURE(VHOST_BACKEND_F_IOTLB_MSG_V2);
+	PRINT_FEATURE(VHOST_BACKEND_F_IOTLB_BATCH);
+	if (~known_features & features) {
+		printf(" UNKNOWN:0x%lx", ~known_features & features);
+	}
+	printf("\n");
+
+	our_features = 0;
+	r = ioctl(vhost_fd, VHOST_SET_BACKEND_FEATURES, &our_features);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_BACKEND_FEATURES)");
+	}
+
+	return vhost_fd;
+}
+
+void vhost_set_mem_table(int vhost_fd, struct iovec *iov, ssize_t iov_cnt)
+{
+	struct vhost_memory *mem =
+		calloc(1, sizeof(struct vhost_memory) +
+				  sizeof(struct vhost_memory_region) * iov_cnt);
+	mem->nregions = iov_cnt;
+	int i;
+	for (i = 0; i < iov_cnt; i++) {
+		mem->regions[i].guest_phys_addr =
+			(uint64_t)(unsigned long)iov[i].iov_base;
+		mem->regions[i].userspace_addr = (uint64_t)(unsigned long)iov[i].iov_base;
+		mem->regions[i].memory_size = iov[i].iov_len;
+	}
+	int r = ioctl(vhost_fd, VHOST_SET_MEM_TABLE, mem);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_MEM_TABLE)");
+	}
+}
+
+/* This marks a buffer as continuing via the next field. */
+#define VIRTQ_DESC_F_NEXT 1
+/* This marks a buffer as write-only (otherwise read-only). */
+#define VIRTQ_DESC_F_WRITE 2
+/* This means the buffer contains a list of buffer descriptors. */
+#define VIRTQ_DESC_F_INDIRECT 4
+
+/* Little-endian */
+struct virtq_desc {
+	uint64_t addr;	/* Address (guest-physical). */
+	uint32_t len;	/* Length. */
+	uint16_t flags; /* The flags as indicated above. */
+	uint16_t next;	/* We chain unused descriptors via this, too */
+} __attribute__((packed));
+
+/* Little-endian */
+struct virtq_avail {
+	volatile uint16_t flags;
+	volatile uint16_t idx;
+	uint16_t ring[];
+	/* Only if VIRTIO_F_EVENT_IDX: le16 used_event; */
+} __attribute__((packed));
+
+/* struct virtq_used_elem { */
+/* 	uint32_t id;  /\* Index of start of used descriptor chain. le32 */
+/* 		       * for padding reasons *\/ */
+/* 	uint32_t len; /\* Total length of the descriptor chain which */
+/* 		       * was written to. *\/ */
+/* } __attribute__((packed)); */
+
+struct virtq_used {
+	uint16_t flags;
+	uint16_t idx;
+	struct virtq_used_elem ring[];
+	/* Only if VIRTIO_F_EVENT_IDX: le16 avail_event; */
+} __attribute__((packed));
+
+struct vring_split {
+	uint32_t num;
+
+	struct virtq_desc *desc;
+	struct virtq_avail *avail;
+	uint16_t *used_event_ptr;
+	struct virtq_used *used;
+	uint16_t *avail_event_ptr;
+
+	int kick;
+	int call;
+	int errfd;
+
+	uint16_t avail_idx_shadow;
+
+	uint32_t desc_free_head;
+	int desc_num_free;
+
+	uint16_t desc_flags;
+
+	uint16_t used_idx_last;
+};
+
+void vring_print_id(struct vring_split *vring, uint32_t id)
+{
+	/* printf("used %d %d\n", vring->used->idx, *vring->used_event_ptr); */
+	/* printf("avail %d %d\n", vring->avail->idx, *vring->avail_event_ptr); */
+	/* return; */
+	printf("id=%d %p %d %d %d\n", id, (void *)vring->desc[id].addr,
+	       vring->desc[id].len, vring->desc[id].flags, vring->desc[id].next);
+}
+
+struct vring_split *vring_split_new(uint16_t num, int bufs_device_readable)
+{
+	struct vring_split *vring = calloc(1, sizeof(struct vring_split));
+	int r = 0;
+	r |= posix_memalign((void **)&vring->desc, 16, sizeof(struct virtq_desc) * num);
+	r |= posix_memalign((void **)&vring->avail, 8,
+			    sizeof(struct virtq_avail) + sizeof(uint16_t) * num +
+				    sizeof(uint16_t));
+	r |= posix_memalign((void **)&vring->used, 8,
+			    sizeof(struct virtq_used) +
+				    sizeof(struct virtq_used_elem) * num +
+				    sizeof(uint16_t));
+	if (r) {
+		error(-1, errno, "posix_memalign()");
+	}
+
+	memset(vring->desc, 0, sizeof(struct virtq_desc) * num);
+	memset(vring->avail, 0,
+	       sizeof(struct virtq_avail) + sizeof(uint16_t) * num + sizeof(uint16_t));
+	vring->used_event_ptr = (void*)((uint8_t *)vring->avail + sizeof(struct virtq_avail) +
+					    sizeof(uint16_t) * num);
+	memset(vring->used, 0,
+	       sizeof(struct virtq_used) + sizeof(struct virtq_used_elem) * num +
+		       sizeof(uint16_t));
+	vring->avail_event_ptr = (void*)((uint8_t *)vring->used + sizeof(struct virtq_used) +
+					 sizeof(struct virtq_used_elem) * num);
+	vring->num = num;
+	//*vring->used_event_ptr +=1;
+
+	vring->kick = eventfd(0, EFD_NONBLOCK);
+	vring->call = eventfd(0, EFD_NONBLOCK);
+	vring->errfd = eventfd(0, EFD_NONBLOCK);
+
+	vring->desc_num_free = num;
+	vring->desc_flags = bufs_device_readable ? 0 : VIRTQ_DESC_F_WRITE;
+
+	if (0) {
+		uint16_t a = 1;
+		write(vring->call, &a, 8);
+	}
+	return vring;
+}
+
+void vhost_setup_vring_split(int vhost_fd, uint16_t index, struct vring_split *vring,
+			     int tap_fd)
+{
+	int r = ioctl(vhost_fd, VHOST_SET_VRING_NUM,
+		      &(struct vhost_vring_state){.index = index, .num = vring->num});
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_VRING_NUM)");
+	}
+	r = ioctl(vhost_fd, VHOST_SET_VRING_KICK,
+		  &(struct vhost_vring_file){.index = index, .fd = vring->kick});
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_VRING_KICK)");
+	}
+	r = ioctl(vhost_fd, VHOST_SET_VRING_CALL,
+		  &(struct vhost_vring_file){.index = index, .fd = vring->call});
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_VRING_CALL)");
+	}
+
+	r = ioctl(vhost_fd, VHOST_SET_VRING_ERR,
+		  &(struct vhost_vring_file){.index = index, .fd = vring->errfd});
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_VRING_ERR)");
+	}
+
+	/* on x86-32 pointers are signed, so you must first convert
+	 * them to unsigned before bringing up to 64 bits to avoid
+	 * sign extension */
+	struct vhost_vring_addr addr = {
+		.index = index,
+		.desc_user_addr = (uint64_t)(unsigned long)vring->desc,
+		.avail_user_addr = (uint64_t)(unsigned long)vring->avail,
+		.used_user_addr = (uint64_t)(unsigned long)vring->used,
+	};
+
+	r = ioctl(vhost_fd, VHOST_SET_VRING_ADDR, &addr);
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_SET_VRING_ADDR)");
+	}
+
+	r = ioctl(vhost_fd, VHOST_NET_SET_BACKEND,
+		  &(struct vhost_vring_file){.index = index, .fd = tap_fd});
+	if (r != 0) {
+		error(-1, errno, "ioctl(VHOST_NET_SET_BACKEND)");
+	}
+}
+
+typedef __u8 __attribute__((__may_alias__)) __u8_alias_t;
+typedef __u16 __attribute__((__may_alias__)) __u16_alias_t;
+typedef __u32 __attribute__((__may_alias__)) __u32_alias_t;
+typedef __u64 __attribute__((__may_alias__)) __u64_alias_t;
+
+static __always_inline void __read_once_size(const volatile void *p, void *res, int size)
+{
+	switch (size) {
+	case 1:
+		*(__u8_alias_t *)res = *(volatile __u8_alias_t *)p;
+		break;
+	case 2:
+		*(__u16_alias_t *)res = *(volatile __u16_alias_t *)p;
+		break;
+	case 4:
+		*(__u32_alias_t *)res = *(volatile __u32_alias_t *)p;
+		break;
+	case 8:
+		*(__u64_alias_t *)res = *(volatile __u64_alias_t *)p;
+		break;
+	default:
+		asm volatile("" : : : "memory");
+		__builtin_memcpy((void *)res, (const void *)p, size);
+		asm volatile("" : : : "memory");
+	}
+}
+#define READ_ONCE(x)                                                                     \
+	({                                                                               \
+		union {                                                                  \
+			typeof(x) __val;                                                 \
+			char __c[1];                                                     \
+		} __u = {.__c = {0}};                                                    \
+		__read_once_size(&(x), __u.__c, sizeof(x));                              \
+		__u.__val;                                                               \
+	})
+
+static __always_inline void __write_once_size(volatile void *p, void *res, int size)
+{
+	switch (size) {
+	case 1:
+		*(volatile __u8_alias_t *)p = *(__u8_alias_t *)res;
+		break;
+	case 2:
+		*(volatile __u16_alias_t *)p = *(__u16_alias_t *)res;
+		break;
+	case 4:
+		*(volatile __u32_alias_t *)p = *(__u32_alias_t *)res;
+		break;
+	case 8:
+		*(volatile __u64_alias_t *)p = *(__u64_alias_t *)res;
+		break;
+	default:
+		asm volatile("" : : : "memory");
+		__builtin_memcpy((void *)p, (const void *)res, size);
+		asm volatile("" : : : "memory");
+	}
+}
+#define WRITE_ONCE(x, val)                                                               \
+	({                                                                               \
+		union {                                                                  \
+			typeof(x) __val;                                                 \
+			char __c[1];                                                     \
+		} __u = {.__val = (val)};                                                \
+		__write_once_size(&(x), __u.__c, sizeof(x));                             \
+		__u.__val;                                                               \
+	})
+int vring_desc_put(struct vring_split *vring, struct iovec *iov, int iov_cnt, int *id_ptr)
+{
+	if (vring->desc_num_free < iov_cnt) {
+		return ENOMEM;
+	}
+
+	//*vring->used_event_ptr +=1;
+
+	vring->desc_num_free -= iov_cnt;
+
+	uint16_t flags = vring->desc_flags;
+
+	uint32_t first = vring->desc_free_head;
+
+	int i;
+	for (i = 0; i < iov_cnt; i++) {
+		int this_idx = vring->desc_free_head;
+
+		int last = i == iov_cnt - 1;
+		struct iovec *io = &iov[i];
+		vring->desc[this_idx % vring->num] = (struct virtq_desc){
+			.addr = (uint64_t)(unsigned long)io->iov_base,
+			.len = io->iov_len,
+			.flags = flags | (last ? 0 : VIRTQ_DESC_F_NEXT),
+			.next = last ? 0 : ((this_idx + 1) % vring->num),
+		};
+		vring->desc_free_head += 1;
+	}
+	// wmb();
+	asm volatile("" ::: "memory");
+	*id_ptr = first;
+
+	vring->avail->ring[vring->avail_idx_shadow % vring->num] = first % vring->num;
+	vring->avail_idx_shadow += 1;
+	__asm__ __volatile__("" : : : "memory");
+	vring->avail->idx = vring->avail_idx_shadow;
+	__asm__ __volatile__("" : : : "memory");
+
+	//int needs_kick = !(vring->used->flags & VIRTQ_USED_F_NO_NOTIFY);
+	return 1; // needs_kick;
+}
+
+int vring_recycle_id(struct vring_split *vring, int id)
+{
+
+	vring->avail->ring[vring->avail_idx_shadow % vring->num] = id % vring->num;
+	vring->avail_idx_shadow += 1;
+	__asm__ __volatile__("" : : : "memory");
+	vring->avail->idx = vring->avail_idx_shadow;
+	__asm__ __volatile__("" : : : "memory");
+
+	int needs_kick;
+	if (DO_EVENT_IDX == 0) {
+		needs_kick = !(READ_ONCE(vring->used->flags) & VIRTQ_USED_F_NO_NOTIFY);
+	} else {
+		needs_kick = (vring->avail_idx_shadow - 1) == *vring->avail_event_ptr;
+	}
+	return needs_kick;
+}
+
+void vring_recycle_bump(struct vring_split *vring, uint16_t d)
+{
+	__asm__ __volatile__("" : : : "memory");
+	*vring->used_event_ptr += d;
+}
+
+void vring_kick(struct vring_split *vring, int cnt)
+{
+	if (cnt == -1) {
+		printf("used: %5d/%5d/%5d avail: %5d/%5d/%5d ",
+		       vring->used_idx_last,
+		       vring->used->idx,
+		       *vring->avail_event_ptr,
+		       vring->avail_idx_shadow,
+		       vring->avail->idx,
+		       *vring->used_event_ptr
+			);
+		return;
+	}
+	uint64_t v = 1;
+	write(vring->kick, &v, sizeof(v));
+}
+
+int vring_callfd(struct vring_split *vring) { return vring->call; }
+
+int vring_errfd(struct vring_split *vring) { return vring->errfd; }
+
+
+void vring_set_suppress_notifications(struct vring_split *vring)
+{
+	if (DO_EVENT_IDX) return ;
+	/* printf("used %d %d\n", vring->used->idx, *vring->used_event_ptr); */
+	/* printf("avail %d %d\n", vring->avail->idx, *vring->avail_event_ptr); */
+	uint32_t flags = READ_ONCE(vring->avail->flags);
+	WRITE_ONCE(vring->avail->flags, flags | VIRTQ_AVAIL_F_NO_INTERRUPT);
+}
+
+int vring_clear_suppress_notifications(struct vring_split *vring)
+{
+	if (DO_EVENT_IDX) return 0;
+	/* printf("used %d %d\n", vring->used->idx, *vring->used_event_ptr); */
+	uint32_t flags = READ_ONCE(vring->avail->flags);
+	int old = !!(flags & VIRTQ_AVAIL_F_NO_INTERRUPT);
+	WRITE_ONCE(vring->avail->flags, flags & ~VIRTQ_AVAIL_F_NO_INTERRUPT);
+	return old;
+}
+
+int vring_get_buf2(struct vring_split *vring, uint32_t *id_ptr, uint32_t *len_ptr)
+{
+	if (vring->used_idx_last != vring->used->idx) {
+		/* if (DO_EVENT_IDX != 0) { */
+		/* 	*vring->used_event_ptr += 1; */
+		/* 	__asm__ __volatile__("" : : : "memory"); */
+		/* } */
+		// barrier
+		asm volatile("" ::: "memory");
+		struct virtq_used_elem e =
+			vring->used->ring[vring->used_idx_last % vring->num];
+		vring->used_idx_last += 1;
+		*id_ptr = e.id;
+		*len_ptr = e.len;
+		return 1;
+	}
+
+	return 0;
+}
+
+int vring_is_empty(struct vring_split *vring)
+{
+	return vring->used_idx_last == READ_ONCE(vring->used->idx);
+}
+
+int vring_get_buf_bulk(struct vring_split *vring, struct virtq_used_elem *le, int le_sz)
+{
+	int i;
+	for(i=0; i < le_sz; i++) {
+		if (vring->used_idx_last == READ_ONCE(vring->used->idx))
+			break;
+		asm volatile("" ::: "memory");
+		le[i] = vring->used->ring[vring->used_idx_last % vring->num];
+		vring->used_idx_last += 1;
+	}
+	return i;
+}
+
+int vring_recycle_bulk(struct vring_split *vring, struct virtq_used_elem *le, uint16_t le_cnt)
+{
+	vring_recycle_bump(vring, le_cnt);
+	__asm__ __volatile__("" : : : "memory");
+
+	int needs_kick = 0;
+	for (int i=0; i<le_cnt; i++) {
+		vring->avail->ring[vring->avail_idx_shadow % vring->num] = le[i].id % vring->num;
+		vring->avail_idx_shadow += 1;
+		__asm__ __volatile__("" : : : "memory");
+		WRITE_ONCE(vring->avail->idx, vring->avail_idx_shadow);
+
+		if (DO_EVENT_IDX == 0) {
+			needs_kick |= !(READ_ONCE(vring->used->flags) & VIRTQ_USED_F_NO_NOTIFY);
+		} else {
+			needs_kick |= (vring->avail_idx_shadow - 1) == READ_ONCE(*vring->avail_event_ptr);
+		}
+	}
+
+	return needs_kick;
+}
+
+
+/*
+
+  int vring_get_buf(struct vring_split *vring, uint8_t **buf_ptr, unsigned int *len_ptr,
+		  int *id_ptr)
+{
+//	printf("used_flag:%d used_idx_last:%d used_idx:%d\n",
+//	       vring->used->flags,
+//	       vring->used_idx_last, vring->used->idx);
+	// rmb
+	asm volatile("" ::: "memory");
+	uint32_t used_idx = READ_ONCE(vring->used->idx);
+	// printf("%d %d\n",vring->used_idx_last,used_idx);
+	if (vring->used_idx_last != used_idx) {
+		asm volatile("" ::: "memory");
+		// We're at the mercy of the other side and could overflow.
+		struct virtq_used_elem e =
+			vring->used->ring[vring->used_idx_last % vring->num];
+		vring->used_idx_last += 1;
+		*len_ptr = e.len;
+		*buf_ptr = (uint8_t *)vring->desc[e.id % vring->num].addr;
+		*id_ptr = e.id;
+		vring->desc_num_free += 1;
+		return 1;
+	}
+
+	return 0;
+}
+*/
+
+/*
+  used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+used: idx_last 65535 idx 65535 event 65535 avail: idx_sha 511 idx 511 event 255 rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+*rx* used: 48422/48422/47746 avail: 48677/48677/48422 *tx* used: 65535/65535/65535 avail:   511/  511/  255  | rx=0.000 kpps / -nanppw  tx=0.000 kpps / -nanppw
+
+*/

--- a/vhost-tap-overload/vhost.c
+++ b/vhost-tap-overload/vhost.c
@@ -19,7 +19,7 @@
 #define VIRTIO_F_RING_RESET 40
 #endif
 
-#define DO_EVENT_IDX 1
+#define DO_EVENT_IDX 0
 
 int vhost_open()
 {
@@ -423,19 +423,8 @@ void vring_recycle_bump(struct vring_split *vring, uint16_t d)
 	*vring->used_event_ptr += d;
 }
 
-void vring_kick(struct vring_split *vring, int cnt)
+void vring_kick(struct vring_split *vring)
 {
-	if (cnt == -1) {
-		printf("used: %5d/%5d/%5d avail: %5d/%5d/%5d ",
-		       vring->used_idx_last,
-		       vring->used->idx,
-		       *vring->avail_event_ptr,
-		       vring->avail_idx_shadow,
-		       vring->avail->idx,
-		       *vring->used_event_ptr
-			);
-		return;
-	}
 	uint64_t v = 1;
 	write(vring->kick, &v, sizeof(v));
 }


### PR DESCRIPTION
Got this code developed by Marek Majkowski, when investigating

- **how to inject packets to kernel the fastest!**

It provides an easy way to do an "overload" benchmark to determine the **maximum performance** of the components involved.

For me ( @netoptimizer ) I'm using this to profile the kernel components.
I think Marek is profiling and optimizing the userspace components.